### PR TITLE
Fix datetime overflow and HTTP client lifecycle bugs

### DIFF
--- a/src/safeclaw/actions/reminder.py
+++ b/src/safeclaw/actions/reminder.py
@@ -1,6 +1,6 @@
 """Reminder action."""
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, TYPE_CHECKING
 
 import dateparser
@@ -51,11 +51,7 @@ class ReminderAction(BaseAction):
 
         if not trigger_time:
             # Default to 1 hour from now
-            trigger_time = datetime.now().replace(
-                hour=datetime.now().hour + 1,
-                minute=0,
-                second=0,
-            )
+            trigger_time = datetime.now() + timedelta(hours=1)
 
         # Ensure it's in the future
         if trigger_time <= datetime.now():

--- a/src/safeclaw/core/crawler.py
+++ b/src/safeclaw/core/crawler.py
@@ -146,6 +146,7 @@ class Crawler:
     async def __aexit__(self, *args):
         if self._client:
             await self._client.aclose()
+            self._client = None
 
     async def fetch(self, url: str, allow_internal: bool = False) -> CrawlResult:
         """Fetch a single URL and extract content."""

--- a/src/safeclaw/core/memory.py
+++ b/src/safeclaw/core/memory.py
@@ -6,7 +6,7 @@ SQLite-based with async support. No cloud required.
 
 import json
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Optional
 
@@ -361,9 +361,7 @@ class Memory:
         """Cache crawl results."""
         assert self._connection is not None
 
-        expires_at = datetime.now().replace(
-            hour=datetime.now().hour + ttl_hours
-        )
+        expires_at = datetime.now() + timedelta(hours=ttl_hours)
 
         await self._connection.execute(
             """
@@ -406,9 +404,7 @@ class Memory:
 
         expires_at = None
         if ttl_seconds:
-            expires_at = datetime.now().replace(
-                second=datetime.now().second + ttl_seconds
-            ).isoformat()
+            expires_at = (datetime.now() + timedelta(seconds=ttl_seconds)).isoformat()
 
         await self._connection.execute(
             """


### PR DESCRIPTION
- Fix "hour must be in 0..23" error by using timedelta instead of datetime.replace() for time calculations in reminder.py and memory.py
- Fix "Cannot send a request, as the client has been closed" error by resetting _client to None after closing in crawler.py __aexit__
 