### PR TITLE
windows compatibility fix 

### DIFF
--- a/src/safeclaw/__main__.py
+++ b/src/safeclaw/__main__.py
@@ -1,0 +1,5 @@
+"""Allow running safeclaw as: python -m safeclaw"""
+from safeclaw.cli import main_cli
+
+if __name__ == "__main__":
+    main_cli()


### PR DESCRIPTION
Allows running SafeClaw via:
  python -m safeclaw run
  python -m safeclaw parse "command"
 