### PR TITLE
Fix exit/quit not working and Ctrl+C not exiting

### DIFF
--- a/src/safeclaw/channels/cli.py
+++ b/src/safeclaw/channels/cli.py
@@ -91,7 +91,8 @@ class CLIChannel(BaseChannel):
                 self._display_response(response)
 
             except KeyboardInterrupt:
-                self.console.print("\n[dim]Interrupted. Type 'quit' to exit.[/dim]")
+                self.console.print("\n[dim]Goodbye![/dim]")
+                break
             except EOFError:
                 break
 
@@ -111,7 +112,8 @@ class CLIChannel(BaseChannel):
         self.console.print(prompt, end="")
 
         loop = asyncio.get_event_loop()
-        return await loop.run_in_executor(None, sys.stdin.readline)
+        line = await loop.run_in_executor(None, sys.stdin.readline)
+        return line.strip()
 
     def _display_response(self, response: str) -> None:
         """Display response with formatting."""


### PR DESCRIPTION
- Strip newline from stdin.readline() so "exit\n" matches "exit"
- Make Ctrl+C actually exit instead of just printing a message
update banner 
 