### PR TITLE
ci: trigger publish workflow on bare-number tags (e.g. 4.2)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+      - "[0-9]*"
 
 jobs:
   build:


### PR DESCRIPTION
The publish workflow only fired on `v*` tags, but every existing tag in this repo is bare (`4.0`, `4.1`, `4.2`). This adds `[0-9]*` to the trigger so a `4.2` tag actually starts a release.

Needed before the existing `4.2` tag can be re-pointed at main and trigger the upload to PyPI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PR8d34uQLu1WtwFeqnHp1z)_