### PR TITLE
fix: surface LLM provider errors to the user + tighten calendar regex

### DIFF
--- a/src/safestclaw/core/conversational.py
+++ b/src/safestclaw/core/conversational.py
@@ -133,15 +133,29 @@ class ConversationalFallback:
         text: str,
         user_id: str,
         has_llm: bool = False,
+        llm_error: str | None = None,
     ) -> str:
         """Return a friendly response for an unparsed message.
 
-        ``has_llm`` lets the caller signal that an LLM/NLU was configured
-        but didn't produce a reply (e.g. provider call failed). When True
-        the orientation line points the user at `setup ai status` so the
-        silent-failure case is debuggable. When False it suggests
-        plugging an LLM in for free-form chat.
+        ``has_llm`` signals that an LLM/NLU was configured but didn't
+        produce a reply for this turn. ``llm_error``, when present, is
+        the actual error message captured from the provider so we can
+        show it to the user instead of silently dropping to canned
+        fallbacks.
         """
+        # When the LLM is configured AND an error fired this turn, lead
+        # with that — it's the most useful thing we can tell the user.
+        # Greeting/thanks/capability replies still come back normally
+        # below since those are useful even when the LLM is down.
+        if has_llm and llm_error:
+            return (
+                f"My LLM didn't reply this turn:\n\n```\n{llm_error}\n```\n\n"
+                f"Run `setup ai status` to check the provider, or "
+                f"`setup ai <new-key>` to swap it. In the meantime I "
+                f"can still handle commands like `summarize <url>`, "
+                f"`news`, `weather <city>`, `remind me to …`."
+            )
+
         if _GREETING.match(text):
             return "Hey 👋 — what would you like me to automate?"
         if _THANKS.match(text):

--- a/src/safestclaw/core/engine.py
+++ b/src/safestclaw/core/engine.py
@@ -348,8 +348,11 @@ class SafestClaw:
                 "blogs, briefings, research — and I'll take it from there. "
                 "(Or `/help` for the raw docs.)"
             )
+        llm_error = getattr(self.nlu, "last_error", None) if self.nlu else None
         return await conv.reply(
-            text, user_id or "", has_llm=self.nlu is not None,
+            text, user_id or "",
+            has_llm=self.nlu is not None,
+            llm_error=llm_error,
         )
 
     async def _handle_chain(

--- a/src/safestclaw/core/llm_installer.py
+++ b/src/safestclaw/core/llm_installer.py
@@ -177,6 +177,7 @@ def setup_with_key(api_key: str, config_path: Path) -> str:
     Returns:
         Status message
     """
+    api_key = (api_key or "").strip()
     provider_name = _detect_provider(api_key)
 
     if not provider_name:

--- a/src/safestclaw/core/nlu.py
+++ b/src/safestclaw/core/nlu.py
@@ -133,6 +133,10 @@ class NLUInterpreter:
         self.temperature: float = float(nlu_config.get("temperature", 0.0))
         self.show_translation: bool = nlu_config.get("show_translation", True)
         self._system_prompt: str | None = None  # lazy-built
+        # Captured on the most recent failed call so the engine /
+        # conversational fallback can show the user *why* the LLM
+        # didn't reply, instead of silently dropping to canned text.
+        self.last_error: str | None = None
 
     def _build_system_prompt(self) -> str:
         """Build the system prompt from all known intents and their examples."""
@@ -219,8 +223,14 @@ class NLUInterpreter:
             max_tokens=512,
         )
 
-        if response.error or not response.content.strip():
-            logger.debug(f"NLU question answering failed: {response.error}")
+        if response.error:
+            self.last_error = response.error
+            logger.warning("NLU question answering failed: %s", response.error)
+            return None
+        if not response.content.strip():
+            self.last_error = "the model returned an empty response"
+            logger.warning("NLU question answering returned empty content")
             return None
 
+        self.last_error = None
         return response.content.strip()

--- a/src/safestclaw/core/parser.py
+++ b/src/safestclaw/core/parser.py
@@ -654,7 +654,11 @@ class CommandParser:
                 patterns=[
                     r"(?:show|what(?:'s| is))\s+(?:on\s+)?my\s+(?:calendar|schedule)",
                     r"(?:add|create|schedule)\s+(?:a\s+)?(?:meeting|event|appointment)\s+(.+)",
-                    r"(?:what(?:'s| is)|do\s+i\s+have)\s+(?:happening\s+)?(?:on\s+)?(.+)",
+                    # Calendar-context "what's happening / what's on" /
+                    # "do I have any meetings" — require a calendar word so
+                    # generic "what is X" questions don't fall in here.
+                    r"(?:what(?:'s| is))\s+(?:happening|going on|scheduled|on(?: the)? agenda)\s*(.*)",
+                    r"do\s+i\s+have\s+(?:any\s+)?(?:meetings?|events?|appointments?|plans?)\b\s*(.*)",
                     r"calendar\s+(today|upcoming|week|import|sync|calendars)\s*(.*)",
                     r"calendar\s+sync",
                 ],


### PR DESCRIPTION
User reported a real Anthropic key in chat with the bot still hitting canned greeting/capability replies. Two things conspired:

1. The calendar intent's regex `(?:what(?:'s| is)|do\s+i\s+have)\s+(?:happening\s+)?(?:on\s+)?(.+)` matched any sentence starting with "what is" — including "what is it like being you", routing chat through the calendar action ("📅 No calendar imported"). Tightened to require a calendar context word (happening / going on / scheduled / agenda) and added a separate pattern for "do i have any meetings/events/plans".

2. nlu.answer_question failures (HTTP errors, empty content, …) logged at debug and silently dropped to the conversational fallback, which then served a canned greeting. The user couldn't tell the LLM was failing.

   * NLUInterpreter now stores the most recent provider error in `self.last_error` and bumps the failure log to WARNING.
   * Engine reads `self.nlu.last_error` and threads it through to ConversationalFallback.reply().
   * The fallback short-circuits to a clear "My LLM didn't reply this turn:\n\n```<actual error>```\n\nRun `setup ai status` …" message before any canned greeting/capability template kicks in, so the user sees the real cause of the silence.

Also reverted the speculative "key looks too short" check from the last commit — keys vary in length per provider and the right place to detect a bad key is the actual provider response.